### PR TITLE
Add 64bit BAR EFI-FB support to Dom0 kernel

### DIFF
--- a/SOURCES/xen_dom0_64bit-efi.patch
+++ b/SOURCES/xen_dom0_64bit-efi.patch
@@ -1,0 +1,39 @@
+--- a/include/xen/interface/xen.h	2019-01-31 07:14:42.000000000 +0000
++++ b/include/xen/interface/xen.h	2022-04-22 17:41:38.053055993 +0000
+@@ -737,6 +722,9 @@
+ 			uint32_t gbl_caps;
+ 			/* Mode attributes (offset 0x0, VESA command 0x4f01). */
+ 			uint16_t mode_attrs;
++			uint16_t pad;
++			/* high 32 bits of lfb_base */
++			uint32_t ext_lfb_base;
+ 		} vesa_lfb;
+ 	} u;
+ };
+--- a/arch/x86/xen/vga.c	2019-01-31 07:14:42.000000000 +0000
++++ b/arch/x86/xen/vga.c	2022-04-22 17:41:22.260930826 +0000
+@@ -57,16 +57,20 @@
+ 		screen_info->rsvd_size = info->u.vesa_lfb.rsvd_size;
+ 		screen_info->rsvd_pos = info->u.vesa_lfb.rsvd_pos;
+ 
++		if (size >= offsetof(struct dom0_vga_console_info,
++				     u.vesa_lfb.ext_lfb_base)
++		    + sizeof(info->u.vesa_lfb.ext_lfb_base)
++		    && info->u.vesa_lfb.ext_lfb_base) {
++			screen_info->ext_lfb_base = info->u.vesa_lfb.ext_lfb_base;
++			screen_info->capabilities |= VIDEO_CAPABILITY_64BIT_BASE;
++		}
++
+ 		if (info->video_type == XEN_VGATYPE_EFI_LFB) {
+ 			screen_info->orig_video_isVGA = VIDEO_TYPE_EFI;
+ 			break;
+ 		}
+ 
+ 		if (size >= offsetof(struct dom0_vga_console_info,
+-				     u.vesa_lfb.gbl_caps)
+-		    + sizeof(info->u.vesa_lfb.gbl_caps))
+-			screen_info->capabilities = info->u.vesa_lfb.gbl_caps;
+-		if (size >= offsetof(struct dom0_vga_console_info,
+ 				     u.vesa_lfb.mode_attrs)
+ 		    + sizeof(info->u.vesa_lfb.mode_attrs))
+ 			screen_info->vesa_attributes = info->u.vesa_lfb.mode_attrs;

--- a/SPECS/kernel-alt.spec
+++ b/SPECS/kernel-alt.spec
@@ -695,6 +695,7 @@ Patch1205: patch-4.19.223-224
 Patch1206: patch-4.19.224-225
 Patch1207: patch-4.19.225-226
 Patch1208: patch-4.19.226-227
+Patch1209: xen_dom0_64bit-efi.patch
 
 Provides: gitsha(ssh://git@code.citrite.net/XSU/linux-stable.git) = dffbba4348e9686d6bf42d54eb0f2cd1c4fb3520
 Provides: gitsha(ssh://git@code.citrite.net/XS/linux.pg.git) = cb3c28f7e8213ef44e5c06369b577a18b86af291
@@ -1042,6 +1043,9 @@ fi
 %{python2_sitearch}/*
 
 %changelog
+* Fri May 13 2022 Andrew Lindh <andrew@netplex.net>
+- Fix UEFI Dom0 boot EFIFB with 64 bit BAR from Xen (from kernel 5.17)
+
 * Thu Feb 03 2022 Rushikesh Jadhav <rushikesh7@gmail.com> - 4.19.227-1
 - Fixes issue #522
 - Cumulative update till 4.19.227


### PR DESCRIPTION
New XCP Dom0 kernel patch to support UEFI 64bit BAR for EFIFB.
Source code from Linux kernel 5.17

Signed-off-by: Andrew Lindh <andrew@netplex.net>