### PR TITLE
Don't provide kernel Provides

### DIFF
--- a/SPECS/kernel-alt.spec
+++ b/SPECS/kernel-alt.spec
@@ -23,7 +23,7 @@
 Name: kernel-alt
 License: GPLv2
 Version: %{uname}
-Release: 3%{?dist}
+Release: 4%{?dist}
 ExclusiveArch: x86_64
 ExclusiveOS: Linux
 Summary: The Linux kernel
@@ -43,9 +43,10 @@ BuildRequires: python2-devel
 BuildRequires: asciidoc xmlto
 BuildRequires: openssl-devel
 AutoReqProv: no
-Provides: kernel-uname-r = %{uname}
-Provides: kernel = %{version}-%{release}
-Provides: kernel-%{_arch} = %{version}-%{release}
+# Don't provide kernel Provides: we don't want kernel-alt to be pulled instead of main kernel
+#Provides: kernel-uname-r = %{uname}
+#Provides: kernel = %{version}-%{release}
+#Provides: kernel-%{_arch} = %{version}-%{release}
 Requires(post): coreutils kmod
 # xcp-python-libs required for handling grub configuration
 Requires(post): xcp-python-libs >= 2.3.2-1.4.xcpng8.1
@@ -717,9 +718,10 @@ Provides: gitsha(ssh://git@code.citrite.net/XS/linux.pg.git) = cb3c28f7e8213ef44
 License: GPLv2
 Summary: Header files for the Linux kernel for use by glibc
 Group: Development/System
-Obsoletes: glibc-kernheaders < 3.0-46
-Provides: glibc-kernheaders = 3.0-46
-Provides: kernel-headers = %{uname}
+# Don't provide kernel Provides: we don't want kernel-alt to be pulled instead of main kernel
+#Obsoletes: glibc-kernheaders < 3.0-46
+#Provides: glibc-kernheaders = 3.0-46
+#Provides: kernel-headers = %{uname}
 Conflicts: kernel-headers < %{uname}
 
 %description headers
@@ -736,8 +738,9 @@ License: GPLv2
 Summary: Development package for building kernel modules to match the %{uname} kernel
 Group: System Environment/Kernel
 AutoReqProv: no
-Provides: kernel-devel-%{_arch} = %{version}-%{release}
-Provides: kernel-devel-uname-r = %{uname}
+# Don't provide kernel Provides: we don't want kernel-alt to be pulled instead of main kernel
+#Provides: kernel-devel-%{_arch} = %{version}-%{release}
+#Provides: kernel-devel-uname-r = %{uname}
 Requires: elfutils-libelf-devel
 
 %description devel
@@ -1044,6 +1047,10 @@ fi
 %{python2_sitearch}/*
 
 %changelog
+* Thu Oct 06 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 4.19.227-4
+- Don't provide kernel Provides
+- We don't want kernel-alt to be pulled as build deps instead of main kernel packages
+
 * Fri Sep 30 2022 Samuel Verschelde <stormi-xcp@ylix.fr> - 4.19.227-3
 - Rebuild for XCP-ng 8.3 alpha
 


### PR DESCRIPTION
We don't want kernel-alt to be accidentally pulled as build deps instead of the main kernel packages.

Various packages in XCP-ng assume there's only one kernel, the main kernel, so kernel-alt providing higher versions for the same provides as the main kernel may cause issues in build dependency resolution.

Signed-off-by: Samuel Verschelde <stormi-xcp@ylix.fr>